### PR TITLE
Australia State checking

### DIFF
--- a/copy_this/modules/fcPayOne/lib/fcporequest.php
+++ b/copy_this/modules/fcPayOne/lib/fcporequest.php
@@ -71,6 +71,7 @@ class fcpoRequest extends oxSuperCfg {
         'ID',
         'TH',
         'IN',
+        'AU',
     );
 
     /*
@@ -2144,6 +2145,9 @@ class fcpoRequest extends oxSuperCfg {
         if (!$sOrderId) {
             $sPayOneUserId = $this->_getPayoneUserIdByCustNr($oUser->oxuser__oxcustnr->value);
             if ($sPayOneUserId) {
+				/**
+                 * @var self $oPORequest
+                 */
                 $oPORequest = oxNew('fcporequest');
                 $oResponse = $oPORequest->sendRequestUpdateuser($oOrder, $oUser);
             }
@@ -2178,6 +2182,9 @@ class fcpoRequest extends oxSuperCfg {
         $oCountry->load($oOrder->oxorder__oxbillcountryid->value);
 
         if ($blIsUpdateUser === false) {
+			/**
+             * TODO: check if that if condition is correctly as request updateuser doesn't have a customerid which is invalid, as said by Payone Technical Support
+             */
             $this->addParameter('customerid', $oUser->oxuser__oxcustnr->value);
         }
         $this->addParameter('salutation', ($oOrder->oxorder__oxbillsal->value == 'MR' ? 'Herr' : 'Frau'), $blIsUpdateUser);


### PR DESCRIPTION
Hi!

As we got problems with Australian cc payments we contacted PayOne, after a short check we saw that state wasn't sended, after checking why I saw that Australia isn't in the array of countries which need state checking.
Are there any information, anywhere, what countries need that? Didn't found it in the technical documentary.

Also added a comment for easier debugging, no the method usage detection works.

And please, someone who really knows the module check my todo! We only have errors in the API log for type updateuser as no customer no. is submitted when customer data is updated. As said by the technical support person I spoke to, the customer no. is needed.
As not knowing how to trigger updateuser it wasn't checkable for me.

michael