### PR TITLE
Paymentmethod description style in flow theme

### DIFF
--- a/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_creditcard_ajax.tpl
+++ b/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_creditcard_ajax.tpl
@@ -129,10 +129,14 @@
                 [{/if}]
                 <div class="clearfix"></div>
                 [{block name="checkout_payment_longdesc"}]
-                    [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-                        <div class="alert alert-info col-lg-offset-3 desc">
-                            [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
-                        </div>
+					[{if $paymentmethod->oxpayments__oxlongdesc->value|trim }]
+						<div class="row">
+							<div class="col-xs-12 col-lg-9 col-lg-offset-3">
+								<div class="alert alert-info">
+			                        [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+				                </div>
+							</div>
+						</div>
                     [{/if}]
                 [{/block}]
             </dd>

--- a/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_creditcard_hosted.tpl
+++ b/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_creditcard_hosted.tpl
@@ -54,7 +54,7 @@
                         <div class="col-lg-9">
                             <span id="cardcvc2" class="inputIframe"></span>
                         </div>
-                    </div>        
+                    </div>
                 [{/if}]
                 <div class="form-group">
                     <label for="expireInput" class="req control-label col-lg-3">[{oxmultilang ident="FCPO_VALID_UNTIL"}]</label>
@@ -84,10 +84,14 @@
                 </div>
                 [{oxid_include_dynamic file=$oViewConf->fcpoGetAbsModuleTemplateFrontendPath('fcpo_payment_creditcard_script.tpl')}]
                 [{block name="checkout_payment_longdesc"}]
-                    [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-                        <div class="alert alert-info col-lg-offset-3 desc">
-                            [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
-                        </div>
+					[{if $paymentmethod->oxpayments__oxlongdesc->value|trim }]
+						<div class="row">
+							<div class="col-xs-12 col-lg-9 col-lg-offset-3">
+								<div class="alert alert-info">
+			                        [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+				                </div>
+							</div>
+						</div>
                     [{/if}]
                 [{/block}]
             </dd>

--- a/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_debitnote.tpl
+++ b/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_debitnote.tpl
@@ -31,7 +31,7 @@
                 </div>
             </div>
             <div class="form-group" id="fcpo_elv_error_blocked">
-                <div class="col-lg-9">  
+                <div class="col-lg-9">
                     <span class="help-block">
                         <ul role="alert" class="list-unstyled text-danger">
                             <li>
@@ -116,11 +116,15 @@
                 </div>
             [{/if}]
             [{block name="checkout_payment_longdesc"}]
-                [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-                    <div class="alert alert-info col-lg-offset-3 desc">
-                        [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
-                    </div>
-                [{/if}]
+				[{if $paymentmethod->oxpayments__oxlongdesc->value|trim }]
+					<div class="row">
+						<div class="col-xs-12 col-lg-9 col-lg-offset-3">
+							<div class="alert alert-info">
+								[{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+							</div>
+						</div>
+					</div>
+				[{/if}]
             [{/block}]
         </dd>
     </dl>

--- a/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_klarna.tpl
+++ b/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_klarna.tpl
@@ -165,11 +165,15 @@
             [{/if}]
 
             [{block name="checkout_payment_longdesc"}]
-                [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-                    <div class="alert alert-info col-lg-offset-3 desc">
-                        [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
-                    </div>
-                [{/if}]
+				[{if $paymentmethod->oxpayments__oxlongdesc->value|trim }]
+					<div class="row">
+						<div class="col-xs-12 col-lg-9 col-lg-offset-3">
+							<div class="alert alert-info">
+								[{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+							</div>
+						</div>
+					</div>
+				[{/if}]
             [{/block}]
         </dd>
     </dl>

--- a/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_onlinetransfer.tpl
+++ b/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_onlinetransfer.tpl
@@ -29,7 +29,7 @@
                             <ul role="alert" class="list-unstyled text-danger">
                                 <li>[{oxmultilang ident="FCPO_ERROR"}]<div id="fcpo_ou_error_content"></div></li>
                             </ul>
-                        </span>       
+                        </span>
                     </div>
                 </div>
                 <div class="form-group">
@@ -144,10 +144,14 @@
                     </div>
                 </div>
                 [{block name="checkout_payment_longdesc"}]
-                    [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-                        <div class="alert alert-info col-lg-offset-3 desc">
-                            [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
-                        </div>
+					[{if $paymentmethod->oxpayments__oxlongdesc->value|trim }]
+						<div class="row">
+							<div class="col-xs-12 col-lg-9 col-lg-offset-3">
+								<div class="alert alert-info">
+			                        [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+				                </div>
+							</div>
+						</div>
                     [{/if}]
                 [{/block}]
             </dd>

--- a/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_payolution_bill.tpl
+++ b/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_payolution_bill.tpl
@@ -23,7 +23,7 @@
         <link href="[{$oViewConf->fcpoGetModuleCssPath('lightview.css')}]" rel="stylesheet">
         <script src="[{$oViewConf->fcpoGetModuleJsPath('jquery-1.10.1.min.js')}]"></script>
         <script src="[{$oViewConf->fcpoGetModuleJsPath()}]lightview/lightview.js"></script>
-        [{if $oView->fcpoShowB2B()}]        
+        [{if $oView->fcpoShowB2B()}]
             <div class="form-group">
                 <label class="req control-label col-lg-3">[{oxmultilang ident="FCPO_PAYOLUTION_USTID"}]</label>
                 <div class="col-lg-9">
@@ -67,11 +67,15 @@
         </div>
 
         [{block name="checkout_payment_longdesc"}]
-            [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-                <div class="alert alert-info col-lg-offset-3 desc">
-                    [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
-                </div>
-            [{/if}]
+			[{if $paymentmethod->oxpayments__oxlongdesc->value|trim }]
+				<div class="row">
+					<div class="col-xs-12 col-lg-9 col-lg-offset-3">
+						<div class="alert alert-info">
+							[{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+						</div>
+					</div>
+				</div>
+			[{/if}]
         [{/block}]
     </dd>
 </dl>

--- a/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_payolution_debitnote.tpl
+++ b/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_payolution_debitnote.tpl
@@ -22,7 +22,7 @@
         <script src="[{$oViewConf->fcpoGetModuleJsPath('jquery-1.10.1.min.js')}]"></script>
         <script src="[{$oViewConf->fcpoGetModuleJsPath()}]lightview/lightview.js"></script>
         <input type="hidden" name="fcpo_mode_[{$sPaymentID}]" value="[{$paymentmethod->fcpoGetOperationMode()}]">
-        
+
         [{if $oView->fcpoShowB2C()}]
             <div class="form-group">
                 <label class="req control-label col-lg-3">[{oxmultilang ident="FCPO_PAYOLUTION_BIRTHDATE"}]</label>
@@ -52,7 +52,7 @@
             <div class="col-lg-9">
                 <input class="form-control js-oxValidate js-oxValidate_notEmpty"  type="text" size="20" maxlength="64" name="dynvalue[fcpo_payolution_debitnote_accountholder]" value="[{$dynvalue.fcpo_payolution_debitnote_accountholder}]" onkeyup="fcHandleDebitInputs();return false;" required="required">
             </div>
-        </div> 
+        </div>
         <div class="form-group">
             <label class="req control-label col-lg-3">[{oxmultilang ident="FCPO_BANK_IBAN"}]</label>
             <div class="col-lg-9">
@@ -75,20 +75,24 @@
                 </div>
             </div>
         </div>
-        
+
         <div class="alert alert-info col-lg-offset-3 desc">
             <input name="dynvalue[fcpo_payolution_debitnote_agreed]" value="agreed" type="checkbox">&nbsp;[{oxmultilang ident="FCPO_PAYOLUTION_AGREEMENT_PART_1"}] <a href='[{$oView->fcpoGetPayolutionAgreementLink()}]' class="lightview fcpoPayolutionAgreeRed" data-lightview-type="iframe" data-lightview-options="width: 800, height: 600, viewport: 'scale',background: { color: '#fff', opacity: 1 },skin: 'light'">[{oxmultilang ident="FCPO_PAYOLUTION_AGREE"}]</a> [{oxmultilang ident="FCPO_PAYOLUTION_AGREEMENT_PART_2"}]
         </div>
         <div class="alert alert-info col-lg-offset-3 desc">
             <input name="dynvalue[fcpo_payolution_debitnote_sepa_agreed]" value="agreed" type="checkbox">&nbsp;[{oxmultilang ident="FCPO_PAYOLUTION_SEPA_AGREEMENT_PART_1"}] <a href='[{$oView->fcpoGetPayolutionSepaAgreementLink()}]' class="lightview fcpoPayolutionAgreeRed" data-lightview-type="iframe" data-lightview-options="width: 800, height: 600, viewport: 'scale',background: { color: '#fff', opacity: 1 },skin: 'light'">[{oxmultilang ident="FCPO_PAYOLUTION_SEPA_AGREE"}]</a>
         </div>
-        
+
         [{block name="checkout_payment_longdesc"}]
-            [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-                <div class="desc">
-                    [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
-                </div>
-            [{/if}]
+			[{if $paymentmethod->oxpayments__oxlongdesc->value|trim }]
+				<div class="row">
+					<div class="col-xs-12 col-lg-9 col-lg-offset-3">
+						<div class="alert alert-info">
+							[{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+						</div>
+					</div>
+				</div>
+			[{/if}]
         [{/block}]
     </dd>
 </dl>

--- a/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_ratepay_bill.tpl
+++ b/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_ratepay_bill.tpl
@@ -66,11 +66,15 @@
                 </div>
             [{/if}]
             [{block name="checkout_payment_longdesc"}]
-                [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-                    <div class="desc">
-                        [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
-                    </div>
-                [{/if}]
+				[{if $paymentmethod->oxpayments__oxlongdesc->value|trim }]
+					<div class="row">
+						<div class="col-xs-12 col-lg-9 col-lg-offset-3">
+							<div class="alert alert-info">
+								[{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+							</div>
+						</div>
+					</div>
+				[{/if}]
             [{/block}]
         </dd>
     </dl>

--- a/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_secinvoice.tpl
+++ b/copy_this/modules/fcPayOne/application/views/frontend/tpl/flow/fcpo_payment_secinvoice.tpl
@@ -44,11 +44,15 @@
         </div>
 
         [{block name="checkout_payment_longdesc"}]
-            [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-                <div class="alert alert-info col-lg-offset-3 desc">
-                    [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
-                </div>
-            [{/if}]
+			[{if $paymentmethod->oxpayments__oxlongdesc->value|trim }]
+				<div class="row">
+					<div class="col-xs-12 col-lg-9 col-lg-offset-3">
+						<div class="alert alert-info">
+							[{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+						</div>
+					</div>
+				</div>
+			[{/if}]
         [{/block}]
     </dd>
 </dl>


### PR DESCRIPTION
- check if payment mehtos is actually set and not only whitespace (use source tab in backend to clear description). If not checked will print empty bootstrap alert-info box
- dont overlead alert and grid classes, align the info box with form elements above