### PR TITLE
TPI-2345: add EPS to hasPaymentMethodsAvailableSubTypes()

### DIFF
--- a/copy_this/modules/fcPayOne/extend/application/controllers/fcPayOnePaymentView.php
+++ b/copy_this/modules/fcPayOne/extend/application/controllers/fcPayOnePaymentView.php
@@ -295,6 +295,7 @@ class fcPayOnePaymentView extends fcPayOnePaymentView_parent {
                 $this->getIdeal(),
                 $this->getP24(),
                 $this->getBancontact(),
+                $this->getEPS(),
             ),
         );
 


### PR DESCRIPTION
Fixes EPS not being displayed TPI-2345.