### PR TITLE
load masterpass js lib only if payment method is active

### DIFF
--- a/copy_this/modules/fcPayOne/extend/core/fcPayOneViewConf.php
+++ b/copy_this/modules/fcPayOne/extend/core/fcPayOneViewConf.php
@@ -557,6 +557,13 @@ class fcPayOneViewConf extends fcPayOneViewConf_parent {
         return $blReturn;
     }
 
+    public function fcpoLoadMasterPassJsLib()
+    {
+        $oPayment = $this->_oFcpoHelper->getFactoryObject('oxpayment');
+        $oPayment->load('fcpomasterpass');
+        return $oPayment->oxpayments__oxactive->value == 1;
+    }
+
     /**
      * Template getter for receiving masterpass button url
      *

--- a/copy_this/modules/fcPayOne/out/blocks/fcpo_base_js_extend.tpl
+++ b/copy_this/modules/fcPayOne/out/blocks/fcpo_base_js_extend.tpl
@@ -1,3 +1,5 @@
 [{$smarty.block.parent}]
-[{oxscript include=$oViewConf->fcpoGetMasterpassJsLibUrl()}]
+[{if $oViewConf->fcpoLoadMasterPassJsLib()}]
+    [{oxscript include=$oViewConf->fcpoGetMasterpassJsLibUrl()}]
+[{/if}]
 [{oxscript include=$oViewConf->fcpoGetModuleJsPath('fcPayOne.js')}]


### PR DESCRIPTION
The master pass JS library has a load of 7.5 kb, although the payment method is not activated. In addition, various scripts are loaded via ajax. This is absolutely unnecessary and creates a not to be despised overhead.