### PR TITLE
OXID-314: use direct_debit instead of pay_now 

### DIFF
--- a/copy_this/modules/fcPayOne/out/src/js/fcPayOne.js
+++ b/copy_this/modules/fcPayOne/out/src/js/fcPayOne.js
@@ -775,7 +775,7 @@ $('#fcpo_klarna_combined_agreed, #klarna_payment_selector').change(
 
         let payment_category_list = {
             "fcpoklarna_invoice" : "pay_later",
-            "fcpoklarna_directdebit" : "pay_now",
+            "fcpoklarna_directdebit" : "direct_debit",
             "fcpoklarna_installments" : "pay_over_time",
         }
 


### PR DESCRIPTION
... on klarna widget init to prevent sofort option
