### PR TITLE
Fix module extend entry roles_bemain for EE edition

### DIFF
--- a/copy_this/modules/fcPayOne/metadata.php
+++ b/copy_this/modules/fcPayOne/metadata.php
@@ -262,6 +262,6 @@ if(class_exists('fcpohelper')) {
                 'block' => 'admin_roles_bemain_form',
                 'file' => 'fcpo_admin_roles_bemain_form',
         );
-        $aModule['extend'][] = array('roles_bemain' => 'fcPayOne/extend/application/controllers/admin/fcPayOneRolesBeMain');
+        $aModule['extend']['roles_bemain'] = 'fcPayOne/extend/application/controllers/admin/fcPayOneRolesBeMain';
     }
 }


### PR DESCRIPTION
OXIDs `extend`-array is an associative array:
```php
'extend' => [
    'roles_bemain' => 'fcPayOne/extend/application/controllers/admin/fcPayOneRolesBeMain',
]
```

The current implementation results in:
```php
'extend' => [
    [
        'roles_bemain' => 'fcPayOne/extend/application/controllers/admin/fcPayOneRolesBeMain',
    ]
]
```